### PR TITLE
Add environment variable template and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# AGVConfig-Traduction Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# OpenAI API Key for translation services
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Optional: OpenAI Organization ID
+# OPENAI_ORG_ID=your_organization_id_here
+
+# Optional: Model selection (default: gpt-3.5-turbo)
+# OPENAI_MODEL=gpt-3.5-turbo
+
+# Optional: Temperature used for translation requests (0.0-1.0)
+# TRANSLATION_TEMPERATURE=0.3

--- a/README.md
+++ b/README.md
@@ -120,9 +120,12 @@ AGVConfig-Traduction/
 
 ### Environment Variables
 
-Create a `.env` file based on `.env.example`:
+A `.env.example` template is provided. Copy it to `.env` and then adjust the
+values as needed:
 
 ```bash
+cp .env.example .env
+
 # Required
 OPENAI_API_KEY=your_openai_api_key_here
 


### PR DESCRIPTION
## Summary
- add example OpenAI env vars to `.env.example`
- document copying `.env.example` to `.env`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f10b85f5c8331a07dc670230f5a69