### PR TITLE
Fix script name reference in modular architecture doc

### DIFF
--- a/comparateur_jsonV9/MODULAR_ARCHITECTURE.md
+++ b/comparateur_jsonV9/MODULAR_ARCHITECTURE.md
@@ -56,10 +56,10 @@ The application has been refactored into a modular architecture with the followi
 
 ### Running the Application
 ```
-python app_latest.py
+python app.py
 ```
 
-Use `app_latest.py` for the fully modular version with all advanced features.
+Use `app.py` for the fully modular version with all advanced features.
 
 ### Keyboard Shortcuts
 


### PR DESCRIPTION
## Summary
- update run instructions in MODULAR_ARCHITECTURE.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f157696048331aaec626ea87848a0