### PR TITLE
Fix file_manager typing and tests

### DIFF
--- a/comparateur_jsonV9/main_controller.py
+++ b/comparateur_jsonV9/main_controller.py
@@ -66,7 +66,8 @@ class FaultEditorController:
         self.app_state = ApplicationState()
 
         # Add missing attributes
-        self.file_manager = None  # File manager instance
+        # Allow any file manager implementation to be assigned
+        self.file_manager: Optional[Any] = None  # File manager instance
 
         # Original application variables
         self.lang = "fr"

--- a/comparateur_jsonV9/tests/test_hello_world.py
+++ b/comparateur_jsonV9/tests/test_hello_world.py
@@ -23,10 +23,10 @@ def test_hello_world():
     """Test basic functionality."""
     assert True
 
-@pytest.raises(ValueError)
 def test_error_handling():
     """Test error handling."""
-    raise ValueError("Test error")
+    with pytest.raises(ValueError):
+        raise ValueError("Test error")
 
 
 

--- a/comparateur_jsonV9/ui/components.py
+++ b/comparateur_jsonV9/ui/components.py
@@ -8,7 +8,7 @@ This module contains reusable UI components for the application.
 
 import tkinter as tk
 from tkinter import ttk
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, Union, Callable
 from config.constants import Colors, Fonts
 
 class StyledFrame(ttk.Frame):

--- a/comparateur_jsonV9/ui/hierarchical_editor.py
+++ b/comparateur_jsonV9/ui/hierarchical_editor.py
@@ -96,7 +96,8 @@ class HierarchicalEditor:
 
         # Add missing attributes
         self.app_state = ApplicationState()
-        self.file_manager = None  # Will be set externally
+        # File manager can be injected from the controller
+        self.file_manager: Optional[Any] = None  # Will be set externally
         self.columns: List[ttk.Frame] = []
         self.main_canvas = tk.Canvas(parent, bg=Colors.BG_MAIN)  # Use tk.Canvas since ttk has no Canvas
         self.main_canvas.pack(fill="both", expand=True)        # Configure scroll region


### PR DESCRIPTION
## Summary
- annotate `file_manager` attribute to accept any file manager implementation
- update hierarchical editor to allow injection of any file manager
- add missing `Callable` import
- fix decorator usage in `test_hello_world`

## Testing
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_683f45b8cd548331bfc1c07d0717ea7d