### PR TITLE
Fix hierarchical editor typing

### DIFF
--- a/comparateur_jsonV9/ui/hierarchical_editor.py
+++ b/comparateur_jsonV9/ui/hierarchical_editor.py
@@ -14,23 +14,27 @@ from config.constants import Colors
 # Configure logging
 logger = logging.getLogger(__name__)
 
-try:
-    from ui.components import StyledFrame
-except ImportError:
-    # Fallback if components module doesn't exist
-    class StyledFrame(tk.Frame):
-        """Extended Frame class that's compatible with Frame type."""
-        pass
+# The hierarchical editor currently doesn't rely on StyledFrame, but keep a
+# lightweight import for future use. Fall back to ``tk.Frame`` if the component
+# module isn't available.
+try:  # pragma: no cover - optional dependency
+    from ui.components import StyledFrame as _StyledFrame
+except ImportError:  # pragma: no cover - running without UI components
+    _StyledFrame = tk.Frame
+
+StyledFrame = _StyledFrame
 
 try:
     from search.search_manager import HierarchicalSearcher as ImportedSearcher
 except ImportError:
     ImportedSearcher = None
 
+
 # Create a utility function for path_to_filename
 def path_to_filename(path: List[int], lang: str = "fr") -> str:
     """Convert a path to a filename."""
     return f"faults_{'_'.join(str(p).zfill(3) for p in path)}_{lang}.json"
+
 
 class SearchBarBuilder:
     """Builder for search bars."""
@@ -45,6 +49,7 @@ class SearchBarBuilder:
         entry.pack(side="left", fill="x", expand=True, padx=5)
         return frame
 
+
 class HierarchicalSearcher:
     """Search functionality for hierarchical data."""
 
@@ -54,10 +59,12 @@ class HierarchicalSearcher:
         self.current_results: List[SearchResult] = []
         self.highlight_callback: Optional[Callable[[SearchResult], None]] = None
 
-    def highlight_result(self, column: Union[tk.Frame, ttk.Frame], row: Union[tk.Frame, ttk.Frame]) -> None:
+    def highlight_result(
+        self, column: Union[tk.Frame, ttk.Frame], row: Union[tk.Frame, ttk.Frame]
+    ) -> None:
         """Highlight a search result."""
-        if hasattr(row, 'configure') and isinstance(row, tk.Frame):
-            row.configure(bg=Colors.YELLOW)
+        if hasattr(row, "configure") and isinstance(row, tk.Frame):
+            row.configure(background=Colors.YELLOW)
 
     def clear_all_highlights(self) -> None:
         """Clear all highlights."""
@@ -67,14 +74,15 @@ class HierarchicalSearcher:
     def _clear_column_highlights(self, column: Union[tk.Frame, ttk.Frame]) -> None:
         """Clear highlights in a specific column."""
         for child in column.winfo_children():
-            if hasattr(child, 'configure') and isinstance(child, tk.Frame):
-                child.configure(bg=Colors.BG_ROW)
+            if hasattr(child, "configure") and isinstance(child, tk.Frame):
+                child.configure(background=Colors.BG_ROW)
 
     def search_in_columns(self, query: str) -> List[SearchResult]:
         """Search for query in columns and return results."""
         results = []
         # Implement search logic here
         return results
+
 
 class HierarchicalEditor:
     """Main hierarchical editor component."""
@@ -90,26 +98,28 @@ class HierarchicalEditor:
 
         # Set up ttk styles
         style = ttk.Style()
-        style.configure('Editor.TFrame', background=Colors.BG_MAIN)
-        style.configure('Column.TFrame', background=Colors.BG_COLUMN)
-        style.configure('Row.TFrame', background=Colors.BG_ROW)
+        style.configure("Editor.TFrame", background=Colors.BG_MAIN)
+        style.configure("Column.TFrame", background=Colors.BG_COLUMN)
+        style.configure("Row.TFrame", background=Colors.BG_ROW)
 
         # Add missing attributes
         self.app_state = ApplicationState()
         self.file_manager = None  # Will be set externally
         self.columns: List[ttk.Frame] = []
-        self.main_canvas = tk.Canvas(parent, bg=Colors.BG_MAIN)  # Use tk.Canvas since ttk has no Canvas
-        self.main_canvas.pack(fill="both", expand=True)        # Configure scroll region
-        self.main_canvas.bind('<Configure>', self._on_frame_configure)
+        self.main_canvas = tk.Canvas(
+            parent, bg=Colors.BG_MAIN
+        )  # Use tk.Canvas since ttk has no Canvas
+        self.main_canvas.pack(fill="both", expand=True)  # Configure scroll region
+        self.main_canvas.bind("<Configure>", self._on_frame_configure)
 
-    def create_columns(self) -> List[ttk.Frame]:
+    def create_columns(self) -> List[Union[tk.Frame, ttk.Frame]]:
         """Create and return column frames."""
         style = ttk.Style()
-        style.configure('Column.TFrame', background=Colors.BG_COLUMN)
+        style.configure("Column.TFrame", background=Colors.BG_COLUMN)
 
         columns = []
         for i in range(3):
-            frame = ttk.Frame(self.parent, style='Column.TFrame')
+            frame = ttk.Frame(self.parent, style="Column.TFrame")
             columns.append(frame)
         return columns
 
@@ -117,12 +127,12 @@ class HierarchicalEditor:
         """Setup the searcher with proper column types."""
         columns = self.create_columns()
         # Convert to Union type for searcher
-        searcher_columns: List[Union[tk.Frame, ttk.Frame]] = columns
+        searcher_columns: List[Union[tk.Frame, ttk.Frame]] = list(columns)
         self.searcher = HierarchicalSearcher(searcher_columns)
 
         def highlight_result(result: SearchResult):
             """Highlight a search result."""
-            if self.searcher and hasattr(self.searcher, 'highlight_result'):
+            if self.searcher and hasattr(self.searcher, "highlight_result"):
                 # Convert result to frame references
                 dummy_column = tk.Frame(self.parent)
                 dummy_row = tk.Frame(dummy_column)
@@ -137,21 +147,29 @@ class HierarchicalEditor:
             self.setup_searcher()
 
         # Create sample results for iteration
-        results = [            SearchResult(
+        results = [
+            SearchResult(
                 query=query,
                 file_path="test.json",
                 line_number=1,
                 context="test",
                 column_index=0,
                 row_index=0,
-                fault_data=FaultData(fault_code="TEST", description="test", severity="info", category="test"),
+                fault_data=FaultData(
+                    fault_code="TEST",
+                    description="test",
+                    severity="info",
+                    category="test",
+                ),
                 match_text="test",
                 file_metadata=FileMetadata(
                     filename="test.json",
                     filepath="test.json",
+                    last_modified="",
+                    file_size=0,
                     language="fr",  # Default language
                     path_components=[0],  # Default path component
-                )
+                ),
             ),
             SearchResult(
                 query=query,
@@ -160,15 +178,22 @@ class HierarchicalEditor:
                 context="test2",
                 column_index=0,
                 row_index=1,
-                fault_data=FaultData(fault_code="TEST2", description="test2", severity="info", category="test"),
+                fault_data=FaultData(
+                    fault_code="TEST2",
+                    description="test2",
+                    severity="info",
+                    category="test",
+                ),
                 match_text="test2",
                 file_metadata=FileMetadata(
                     filename="test2.json",
                     filepath="test2.json",
+                    last_modified="",
+                    file_size=0,
                     language="fr",  # Default language
                     path_components=[0],  # Default path component
-                )
-            )
+                ),
+            ),
         ]
 
         for result in results:
@@ -177,18 +202,20 @@ class HierarchicalEditor:
 
     def clear_highlights(self):
         """Clear all highlights."""
-        if self.searcher and hasattr(self.searcher, 'clear_all_highlights'):
+        if self.searcher and hasattr(self.searcher, "clear_all_highlights"):
             self.searcher.clear_all_highlights()
 
     def _ensure_result_visible(self, row: tk.Frame):
         """Ensure the result row is visible."""
-        if hasattr(row, 'update_idletasks'):
+        if hasattr(row, "update_idletasks"):
             row.update_idletasks()
 
-    def set_callbacks(self,
-                     on_select: Optional[Callable[[Any], None]] = None,
-                     on_edit: Optional[Callable[[Any], None]] = None,
-                     on_save: Optional[Callable[[Any], None]] = None):
+    def set_callbacks(
+        self,
+        on_select: Optional[Callable[[Any], None]] = None,
+        on_edit: Optional[Callable[[Any], None]] = None,
+        on_save: Optional[Callable[[Any], None]] = None,
+    ):
         """Set callback functions."""
         if on_select:
             self.on_item_select = on_select
@@ -208,18 +235,25 @@ class HierarchicalEditor:
         except Exception as e:
             logger.error(f"Error clearing columns: {e}")
 
-    def display_column(self, fault_list: List[Any], path: List[int], filename: str, level: int):
+    def display_column(
+        self, fault_list: List[Any], path: List[int], filename: str, level: int
+    ):
         """Display a column of fault data."""
-        try:            # Create column frame
+        try:  # Create column frame
             style = ttk.Style()
-            style.configure('Column.TFrame', background=Colors.BG_COLUMN)
+            style.configure("Column.TFrame", background=Colors.BG_COLUMN)
 
-            col_frame = ttk.Frame(self.parent, style='Column.TFrame')
+            col_frame = ttk.Frame(self.parent, style="Column.TFrame")
             col_frame.pack(side="left", fill="both", expand=False)
 
             # Add to columns list
             if level >= len(self.columns):
-                self.columns.extend([ttk.Frame(self.parent, style='Column.TFrame') for _ in range(level - len(self.columns) + 1)])
+                self.columns.extend(
+                    [
+                        ttk.Frame(self.parent, style="Column.TFrame")
+                        for _ in range(level - len(self.columns) + 1)
+                    ]
+                )
             self.columns[level] = col_frame
 
             # Display fault items
@@ -229,14 +263,14 @@ class HierarchicalEditor:
                         fault_code=fault.get("FaultCode", ""),
                         description=fault.get("Description", ""),
                         severity=fault.get("Severity", "info"),
-                        category=fault.get("Category", "general")
+                        category=fault.get("Category", "general"),
                     )
                 else:
                     fault_data = FaultData(
                         fault_code=str(i),
                         description=str(fault),
                         severity="info",
-                        category="general"
+                        category="general",
                     )
 
                 # Create row widget
@@ -244,8 +278,12 @@ class HierarchicalEditor:
                 row_frame.pack(fill="x", pady=1)
 
                 # Add fault display
-                label = tk.Label(row_frame, text=fault_data.description,
-                               bg=Colors.BG_ROW, fg=Colors.FG_TEXT)
+                label = tk.Label(
+                    row_frame,
+                    text=fault_data.description,
+                    bg=Colors.BG_ROW,
+                    fg=Colors.FG_TEXT,
+                )
                 label.pack(side="left", fill="x", expand=True)
 
             logger.info(f"Displayed column with {len(fault_list)} items")
@@ -272,11 +310,13 @@ class HierarchicalEditor:
                 filename=filename,
                 filepath=f"{self.app_state.base_directory}/{filename}",
                 last_modified="now",
-                file_size=0
+                file_size=0,
+                language=self.app_state.current_language,
+                path_components=new_path,
             )
 
             # Load the file if file_manager is available
-            if self.file_manager and hasattr(self.file_manager, 'load_file'):
+            if self.file_manager and hasattr(self.file_manager, "load_file"):
                 data = self.file_manager.load_file(filename)
                 self.app_state.current_path = new_path
 
@@ -308,11 +348,11 @@ class HierarchicalEditor:
                 self.setup_searcher()
 
             # Clear previous highlights
-            if self.app_state and hasattr(self.app_state, 'current_language'):
+            if self.app_state and hasattr(self.app_state, "current_language"):
                 logger.info(f"Searching for: {query}")
 
             # Perform search
-            if self.searcher and hasattr(self.searcher, 'search_in_columns'):
+            if self.searcher and hasattr(self.searcher, "search_in_columns"):
                 results = self.searcher.search_in_columns(query)
 
                 # Process results
@@ -322,7 +362,7 @@ class HierarchicalEditor:
                         fault_code="SEARCH",
                         description=result.context,
                         severity="info",
-                        category="search"
+                        category="search",
                     )
 
                     # Highlight if needed
@@ -344,14 +384,21 @@ class HierarchicalEditor:
 
             # Navigate to the appropriate level
             # This would implement the logic to navigate to the specific result
-            logger.info(f"Navigating to result: {result.file_path}:{result.line_number}")
+            logger.info(
+                f"Navigating to result: {result.file_path}:{result.line_number}"
+            )
 
         except Exception as e:
             logger.error(f"Error navigating to result: {e}")
 
-    def highlight_search_result(self, column_index: int, row_index: int,
-                              fault_data: FaultData, match_text: str,
-                              file_metadata: FileMetadata):
+    def highlight_search_result(
+        self,
+        column_index: int,
+        row_index: int,
+        fault_data: FaultData,
+        match_text: str,
+        file_metadata: FileMetadata,
+    ):
         """Highlight a specific search result."""
         try:
             if column_index < len(self.columns) and self.columns[column_index]:
@@ -361,15 +408,19 @@ class HierarchicalEditor:
                 children = column.winfo_children()
                 if row_index < len(children):
                     row = children[row_index]
-                    if hasattr(row, 'configure'):
-                        row.configure(bg=Colors.YELLOW)                    # Ensure result is visible
-                    if self.main_canvas and hasattr(row, 'winfo_y'):
+                    if hasattr(row, "configure"):
+                        row.configure(
+                            background=Colors.YELLOW
+                        )  # Ensure result is visible
+                    if self.main_canvas and hasattr(row, "winfo_y"):
                         # Get relative position of row and scroll to it
                         y_position = row.winfo_y()
                         canvas_height = self.main_canvas.winfo_height()
                         if canvas_height > 0:  # Avoid division by zero
                             # Convert to relative position (0.0 to 1.0)
-                            relative_position = max(0.0, min(1.0, y_position / canvas_height))
+                            relative_position = max(
+                                0.0, min(1.0, y_position / canvas_height)
+                            )
                             self.main_canvas.yview_moveto(relative_position)
 
         except Exception as e:
@@ -384,7 +435,11 @@ class HierarchicalEditor:
 
                 # Scroll to position
                 canvas_height = self.main_canvas.winfo_height()
-                total_height = self.main_canvas.bbox("all")[3] if self.main_canvas.bbox("all") else canvas_height
+                total_height = (
+                    self.main_canvas.bbox("all")[3]
+                    if self.main_canvas.bbox("all")
+                    else canvas_height
+                )
 
                 if total_height > canvas_height:
                     fraction = y_position / total_height
@@ -396,10 +451,10 @@ class HierarchicalEditor:
     def clear_search_highlights(self):
         """Clear all search highlights."""
         try:
-            if self.app_state and hasattr(self.app_state, 'current_language'):
+            if self.app_state and hasattr(self.app_state, "current_language"):
                 logger.info("Clearing search highlights")
 
-            if self.searcher and hasattr(self.searcher, 'clear_all_highlights'):
+            if self.searcher and hasattr(self.searcher, "clear_all_highlights"):
                 self.searcher.clear_all_highlights()
 
         except Exception as e:
@@ -409,7 +464,7 @@ class HierarchicalEditor:
         """Save the current editor state."""
         try:
             if self.app_state:
-                self.app_state.last_modified = __import__('datetime').datetime.now()
+                self.app_state.last_modified = __import__("datetime").datetime.now()
                 logger.info("Current state saved")
 
         except Exception as e:
@@ -421,7 +476,7 @@ class HierarchicalEditor:
             self.app_state = state
 
             # Restore file manager if available
-            if self.file_manager and hasattr(self.file_manager, 'set_base_directory'):
+            if self.file_manager and hasattr(self.file_manager, "set_base_directory"):
                 if state.base_directory:
                     self.file_manager.set_base_directory(state.base_directory)
 
@@ -430,11 +485,13 @@ class HierarchicalEditor:
                 # Rebuild columns for the saved path
                 for level in range(len(state.current_path)):
                     if state.current_path[level] != 255:  # Valid level
-                        path = state.current_path[:level+1]
+                        path = state.current_path[: level + 1]
                         filename = path_to_filename(path, state.current_language)
 
                         # Load and display if file manager is available
-                        if self.file_manager and hasattr(self.file_manager, 'load_file'):
+                        if self.file_manager and hasattr(
+                            self.file_manager, "load_file"
+                        ):
                             try:
                                 data = self.file_manager.load_file(filename)
                                 fault_list = data.get("FaultDetailList", [])


### PR DESCRIPTION
## Summary
- clean up StyledFrame import logic
- make `create_columns` return union type and pass columns properly to searcher
- fill in required fields when creating `FileMetadata`
- ensure background color uses supported keyword

## Testing
- `black comparateur_jsonV9/ui/hierarchical_editor.py`
- `flake8` *(fails: command not found)*
- `mypy comparateur_jsonV9/ui/hierarchical_editor.py` *(fails: several errors)*
- `pytest` *(fails: 2 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_683f45a6b4d08331a0583e48d7c2aefc