### PR TITLE
Fix type hints and update tests

### DIFF
--- a/comparateur_jsonV9/tests/test_hello_world.py
+++ b/comparateur_jsonV9/tests/test_hello_world.py
@@ -2,20 +2,27 @@
 
 try:
     import pytest
-except ImportError:
-    # Create a minimal pytest-like interface for basic testing
+except ImportError:  # pragma: no cover - used only when pytest is unavailable
     class MockPytest:
+        """Minimal pytest-like helper supporting the raises context manager."""
+
+        class RaisesContext:
+            def __init__(self, exc_type):
+                self.exc_type = exc_type
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                if exc_type is None:
+                    raise AssertionError(
+                        f"Expected {self.exc_type.__name__} but none was raised"
+                    )
+                return issubclass(exc_type, self.exc_type)
+
         @staticmethod
         def raises(exception_type):
-            def decorator(func):
-                def wrapper(*args, **kwargs):
-                    try:
-                        func(*args, **kwargs)
-                        raise AssertionError(f"Expected {exception_type.__name__} but none was raised")
-                    except exception_type:
-                        pass  # Expected exception was raised
-                return wrapper
-            return decorator
+            return MockPytest.RaisesContext(exception_type)
 
     pytest = MockPytest()
 
@@ -23,10 +30,10 @@ def test_hello_world():
     """Test basic functionality."""
     assert True
 
-@pytest.raises(ValueError)
 def test_error_handling():
     """Test error handling."""
-    raise ValueError("Test error")
+    with pytest.raises(ValueError):
+        raise ValueError("Test error")
 
 
 

--- a/comparateur_jsonV9/ui/components.py
+++ b/comparateur_jsonV9/ui/components.py
@@ -8,7 +8,7 @@ This module contains reusable UI components for the application.
 
 import tkinter as tk
 from tkinter import ttk
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, Union, Callable
 from config.constants import Colors, Fonts
 
 class StyledFrame(ttk.Frame):
@@ -140,7 +140,7 @@ def configure_styles():
 class ProgressDialog(tk.Toplevel):
     """A progress dialog window."""
 
-    def __init__(self, parent: Union[tk.Widget, tk.Tk, tk.Toplevel], title: str = "Progress"):
+    def __init__(self, parent: Union[tk.Tk, tk.Toplevel], title: str = "Progress"):
         """Initialize progress dialog."""
         super().__init__(parent)
         self.title(title)
@@ -229,7 +229,7 @@ class ToolbarBuilder:
     """Constructeur pour les barres d'outils"""
 
     @staticmethod
-    def create_main_toolbar(parent, callbacks: Dict[str, Callable]) -> tk.Frame:
+    def create_main_toolbar(parent, callbacks: Dict[str, Callable]) -> ttk.Frame:
         """Crée la barre d'outils principale"""
         toolbar = StyledFrame(parent, style_type="toolbar")
 
@@ -252,7 +252,7 @@ class ToolbarBuilder:
         return toolbar.as_tk_frame()
 
     @staticmethod
-    def create_flat_editor_toolbar(parent, callbacks: Dict[str, Callable]) -> tk.Frame:
+    def create_flat_editor_toolbar(parent, callbacks: Dict[str, Callable]) -> ttk.Frame:
         """Crée la barre d'outils pour l'éditeur plat"""
         toolbar = StyledFrame(parent, style_type="toolbar")
 


### PR DESCRIPTION
## Summary
- support `Callable` and fix ProgressDialog typing
- return `ttk.Frame` from toolbar builders
- rework helper test to use `pytest.raises` context manager

## Testing
- `pytest -q` *(fails: _tkinter.TclError: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_683f45b0f3648331ab6367d06883cb32