### PR TITLE
Make translation model configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# AGVConfig-Traduction Environment Configuration
+# Copy this file to .env and fill in your actual values
+
+# OpenAI API Key for translation services
+# Get your API key from: https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Optional: OpenAI Organization ID (if you're part of an organization)
+# OPENAI_ORG_ID=your_organization_id_here
+
+# Optional: Model selection (default: gpt-4o-mini)
+# OPENAI_MODEL=gpt-4o-mini
+# To use GPT-4 for higher accuracy, set:
+# OPENAI_MODEL=gpt-4
+
+# Optional: Translation model temperature (0.0-1.0, default: 0.1)
+# TRANSLATION_TEMPERATURE=0.1

--- a/README.md
+++ b/README.md
@@ -128,8 +128,11 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # Optional
 OPENAI_ORG_ID=your_organization_id_here
-OPENAI_MODEL=gpt-3.5-turbo
-TRANSLATION_TEMPERATURE=0.3
+# Default model
+OPENAI_MODEL=gpt-4o-mini
+# Use GPT-4 for best results
+# OPENAI_MODEL=gpt-4
+TRANSLATION_TEMPERATURE=0.1
 ```
 
 ### Supported Languages
@@ -181,7 +184,7 @@ File naming convention: `faults_XXX_YYY_ZZZ_WWW_[lang].json`
 
 Run the test script to verify your configuration:
 ```bash
-python test_translation.py
+python comparateur_jsonV9/test_translation.py
 ```
 
 ## 🧪 Development

--- a/comparateur_jsonV9/.env.example
+++ b/comparateur_jsonV9/.env.example
@@ -8,8 +8,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Optional: OpenAI Organization ID (if you're part of an organization)
 # OPENAI_ORG_ID=your_organization_id_here
 
-# Optional: Model selection (default: gpt-3.5-turbo)
-# OPENAI_MODEL=gpt-3.5-turbo
+# Optional: Model selection (default: gpt-4o-mini)
+# OPENAI_MODEL=gpt-4o-mini
+# To use GPT-4 for higher accuracy, set:
+# OPENAI_MODEL=gpt-4
 
-# Optional: Translation model temperature (0.0-1.0, default: 0.3)
-# TRANSLATION_TEMPERATURE=0.3
+# Optional: Translation model temperature (0.0-1.0, default: 0.1)
+# TRANSLATION_TEMPERATURE=0.1

--- a/comparateur_jsonV9/translate.py
+++ b/comparateur_jsonV9/translate.py
@@ -7,10 +7,14 @@ env_path = os.path.join(os.path.dirname(__file__), '..', '.env')
 load_dotenv(env_path)
 
 # Récupération de la clé API
-OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
     print("⚠️ OPENAI_API_KEY non trouvée, utilisation d'une clé de test")
     OPENAI_API_KEY = "sk-test-key-for-development"
+
+# Sélection du modèle et de la température
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+TRANSLATION_TEMPERATURE = float(os.getenv("TRANSLATION_TEMPERATURE", "0.1"))
 
 # Configuration du client OpenAI
 client = OpenAI(api_key=OPENAI_API_KEY)
@@ -40,7 +44,7 @@ def traduire(text, target_lang):
 
     try:
         response = client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=OPENAI_MODEL,
             messages=[
                 {
                     "role": "system",
@@ -103,7 +107,7 @@ Langue cible : {target_language}"""
                 }
             ],
             max_tokens=500,
-            temperature=0.1
+            temperature=TRANSLATION_TEMPERATURE
         )
 
         content = response.choices[0].message.content


### PR DESCRIPTION
## Summary
- allow configuring model and temperature via `.env`
- update `.env.example` with default GPT-4o-mini settings
- document new variables in the README

## Testing
- `python comparateur_jsonV9/test_translation.py`


------
https://chatgpt.com/codex/tasks/task_b_68402cb7b6dc8331a8c437288ac235c1