### PR TITLE
Replace bare except clauses

### DIFF
--- a/comparateur_jsonV9/apply_improvements.py
+++ b/comparateur_jsonV9/apply_improvements.py
@@ -7,6 +7,7 @@ Ce script crée une version améliorée de l'application avec une meilleure gest
 
 import os
 import shutil
+import tkinter as tk
 from datetime import datetime
 
 def create_backup():
@@ -312,7 +313,7 @@ def create_improved_ui_methods():
             try:
                 if hasattr(self, 'root') and self.root:
                     self.root.quit()
-            except:
+            except tk.TclError:
                 pass
 
     def _save_user_preferences(self):

--- a/comparateur_jsonV9/archive/old_sync_versions/sync_one_improved.py
+++ b/comparateur_jsonV9/archive/old_sync_versions/sync_one_improved.py
@@ -137,8 +137,8 @@ def sync_file(source_file_path, force_retranslate=False):
                 try:
                     with open(target_file, 'r', encoding='utf-8') as f:
                         target_data = json.load(f)
-                except:
-                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier: {e}")
                     target_data = {}
 
             # Synchroniser les données avec la logique améliorée

--- a/comparateur_jsonV9/archive/old_sync_versions/sync_one_old.py
+++ b/comparateur_jsonV9/archive/old_sync_versions/sync_one_old.py
@@ -195,8 +195,8 @@ def sync_file(source_file_path, force_retranslate=False):    """
                 try:
                     with open(target_file, 'r', encoding='utf-8') as f:
                         target_data = json.load(f)
-                except:
-                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier: {e}")
                     target_data = {}
 
             # Synchroniser les données

--- a/comparateur_jsonV9/archive/old_sync_versions/sync_one_v2.py
+++ b/comparateur_jsonV9/archive/old_sync_versions/sync_one_v2.py
@@ -125,8 +125,8 @@ def sync_file(source_file_path, force_retranslate=False):
                 try:
                     with open(target_file, 'r', encoding='utf-8') as f:
                         target_data = json.load(f)
-                except:
-                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier: {e}")
                     target_data = {}
 
             # Synchroniser les données avec la logique améliorée

--- a/comparateur_jsonV9/archive/old_sync_versions/sync_one_v3.py
+++ b/comparateur_jsonV9/archive/old_sync_versions/sync_one_v3.py
@@ -163,8 +163,8 @@ def sync_file(source_file_path, force_retranslate=False):
                 try:
                     with open(target_file, 'r', encoding='utf-8') as f:
                         target_data = json.load(f)
-                except:
-                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier: {e}")
                     target_data = {}
 
             # Synchroniser les données avec la logique améliorée

--- a/comparateur_jsonV9/archive/old_sync_versions/sync_one_v4.py
+++ b/comparateur_jsonV9/archive/old_sync_versions/sync_one_v4.py
@@ -19,6 +19,7 @@ from translate import traduire
 # Support pour la détection de langue (optionnel)
 try:
     from langdetect import detect
+    from langdetect.lang_detect_exception import LangDetectException
     LANGDETECT_AVAILABLE = True
 except ImportError:
     LANGDETECT_AVAILABLE = False
@@ -154,8 +155,8 @@ def sync_file(source_file_path, force_retranslate=False):
                 try:
                     with open(target_file, 'r', encoding='utf-8') as f:
                         target_data = json.load(f)
-                except:
-                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier: {e}")
                     target_data = {}
 
             # Synchroniser les données
@@ -217,7 +218,7 @@ def sync_file(source_file_path, force_retranslate=False):
                         detected_lang = detect(target_desc)
                         if detected_lang != target_lang:
                             should_translate = True
-                    except:
+                    except LangDetectException:
                         pass
 
                 if should_translate:

--- a/comparateur_jsonV9/fix_headers_and_retranslate.py
+++ b/comparateur_jsonV9/fix_headers_and_retranslate.py
@@ -61,8 +61,8 @@ def fix_headers_and_retranslate(source_file_path, force_retranslate=False):
                     with open(target_file, 'r', encoding='utf-8') as f:
                         target_data = json.load(f)
                     print(f"  📂 Fichier existant chargé")
-                except:
-                    print(f"  ⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"  ⚠️ Erreur lors de la lecture de {target_file}, création d'un nouveau fichier: {e}")
                     target_data = {}
             else:
                 print(f"  📄 Création d'un nouveau fichier")

--- a/comparateur_jsonV9/test_app.py
+++ b/comparateur_jsonV9/test_app.py
@@ -68,14 +68,14 @@ class TestFaultEditorBase(unittest.TestCase):
         """Nettoyage après chaque test"""
         try:
             self.root.destroy()
-        except:
+        except tk.TclError:
             pass
 
         # Nettoyer les fichiers temporaires
         import shutil
         try:
             shutil.rmtree(self.temp_dir)
-        except:
+        except OSError:
             pass
 
 class TestFaultEditorInitialization(TestFaultEditorBase):

--- a/comparateur_jsonV9/test_simple.py
+++ b/comparateur_jsonV9/test_simple.py
@@ -37,11 +37,11 @@ class TestFaultEditorBasic(unittest.TestCase):
         try:
             if hasattr(self, 'app') and self.app:
                 self.app.root.destroy()
-        except:
+        except tk.TclError:
             pass
         try:
             self.root.destroy()
-        except:
+        except tk.TclError:
             pass
 
     def test_app_can_be_created(self):
@@ -109,12 +109,12 @@ class TestFileOperations(unittest.TestCase):
             if os.path.exists(self.test_file):
                 os.remove(self.test_file)
             os.rmdir(self.temp_dir)
-        except:
+        except OSError:
             pass
         try:
             self.app.root.destroy()
             self.root.destroy()
-        except:
+        except tk.TclError:
             pass
 
     def test_load_valid_json(self):


### PR DESCRIPTION
## Summary
- clarify exception handling by importing tkinter
- replace bare `except:` clauses with specific exceptions in utility and test files
- handle JSON and language detection errors explicitly in archived sync scripts

## Testing
- `python comparateur_jsonV9/validate_improvements.py`

------
https://chatgpt.com/codex/tasks/task_b_6840678f1f3483319ce55386dda11858