### PR TITLE
Improve Python error visibility

### DIFF
--- a/comparateur_jsonV9/__init__.py
+++ b/comparateur_jsonV9/__init__.py
@@ -21,11 +21,16 @@ __author__ = "Noovelia"
 __license__ = "MIT"
 
 # Main imports for package-level access
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
 try:
     from .translate import traduire, OPENAI_API_KEY
-except ImportError:
-    # Handle cases where dependencies might not be installed
-    pass
+except ImportError as e:
+    logger.warning(f"Impossible d'importer translate: {e}")
+    traceback.print_exc()
 
 # Supported languages
 SUPPORTED_LANGUAGES = ['fr', 'en', 'es']

--- a/comparateur_jsonV9/app.py
+++ b/comparateur_jsonV9/app.py
@@ -8,6 +8,7 @@ from functools import partial
 from translate import traduire
 import re
 import logging
+import traceback
 from datetime import datetime
 
 # Imports pour la gestion d'erreurs améliorée
@@ -324,7 +325,8 @@ class FaultEditor:
                 if hasattr(widget, 'config'):
                     widget.config(state=state)  # type: ignore
             except tk.TclError:
-                pass    # --- Fonctions pour lancer les scripts externes ---
+                logger.warning("TclError lors du changement d'état d'un widget")
+                traceback.print_exc()
     def run_sync_all(self):
         cmd = ["python", "sync_all.py"]
         self.run_command(cmd, desc="Synchroniser tous les fichiers")
@@ -535,12 +537,15 @@ class FaultEditor:
             }
         except subprocess.SubprocessError as e:
             logger.error(f"Erreur subprocess lors de la vérification de cohérence : {e}")
+            traceback.print_exc()
             return {'success': False, 'output': '', 'errors': str(e), 'fixed': False}
         except (OSError, FileNotFoundError) as e:
             logger.error(f"Erreur fichier lors de la vérification de cohérence : {e}")
+            traceback.print_exc()
             return {'success': False, 'output': '', 'errors': f"Fichier non trouvé: {str(e)}", 'fixed': False}
         except Exception as e:
             logger.error(f"Erreur inattendue lors de la vérification de cohérence : {e}")
+            traceback.print_exc()
             return {'success': False, 'output': '', 'errors': str(e), 'fixed': False}
 
     def run_spelling_check_step(self, dossier_base):
@@ -568,18 +573,22 @@ class FaultEditor:
 
         except subprocess.SubprocessError as e:
             logger.error(f"Erreur subprocess lors de la vérification orthographique : {e}")
+            traceback.print_exc()
             print(f"❌ Erreur subprocess lors de la vérification orthographique : {e}")
             return {'success': False, 'output': '', 'errors': str(e)}
         except FileNotFoundError as e:
             logger.error(f"Script verifier_orthographe.py introuvable : {e}")
+            traceback.print_exc()
             print(f"❌ Script verifier_orthographe.py introuvable : {e}")
             return {'success': False, 'output': '', 'errors': str(e)}
         except PermissionError as e:
             logger.error(f"Erreur d'accès lors de la vérification orthographique : {e}")
+            traceback.print_exc()
             print(f"❌ Erreur d'accès lors de la vérification orthographique : {e}")
             return {'success': False, 'output': '', 'errors': str(e)}
         except (OSError, UnicodeDecodeError) as e:
             logger.error(f"Erreur système lors de la vérification orthographique : {e}")
+            traceback.print_exc()
             print(f"❌ Erreur système lors de la vérification orthographique : {e}")
             return {'success': False, 'output': '', 'errors': str(e)}
 
@@ -606,12 +615,15 @@ class FaultEditor:
             }
         except subprocess.SubprocessError as e:
             logger.error(f"Erreur subprocess lors de la correction des headers : {e}")
+            traceback.print_exc()
             return {'success': False, 'output': '', 'errors': str(e), 'fixed': False}
         except (OSError, FileNotFoundError) as e:
             logger.error(f"Erreur fichier lors de la correction des headers : {e}")
+            traceback.print_exc()
             return {'success': False, 'output': '', 'errors': f"Fichier non trouvé: {str(e)}", 'fixed': False}
         except Exception as e:
             logger.error(f"Erreur inattendue lors de la correction des headers : {e}")
+            traceback.print_exc()
             return {'success': False, 'output': '', 'errors': str(e), 'fixed': False}
 
     def show_comprehensive_results(self, results, dossier_base):
@@ -1428,8 +1440,9 @@ class FaultEditor:
             row.winfo_exists()
             self.render_row(row, fault, idx, path, level, filename)
         except tk.TclError:
-            # Widget has been destroyed (e.g., during language change), just clear the editing info
-            pass
+            # Widget has been destroyed (e.g., during language change)
+            logger.debug("Widget détruit avant fin d'édition")
+            traceback.print_exc()
 
         self.editing_info = None
 

--- a/comparateur_jsonV9/check_coherence.py
+++ b/comparateur_jsonV9/check_coherence.py
@@ -11,6 +11,7 @@ import sys
 import json
 import argparse
 from collections import defaultdict
+import traceback
 
 def load_json_safe(file_path):
     """Charge un fichier JSON de manière sécurisée."""
@@ -19,6 +20,7 @@ def load_json_safe(file_path):
             return json.load(f)
     except Exception as e:
         print(f"❌ Erreur lors du chargement de {file_path}: {e}")
+        traceback.print_exc()
         return None
 
 def extract_ids_from_filename(filename):
@@ -282,6 +284,7 @@ def fix_metadata_errors(files_group, errors):
                 print(f"  ✅ Fichier sauvegardé: {filename}")
             except Exception as e:
                 print(f"  ❌ Erreur sauvegarde {filename}: {e}")
+                traceback.print_exc()
 
     return fixes_applied
 

--- a/comparateur_jsonV9/validate_app.py
+++ b/comparateur_jsonV9/validate_app.py
@@ -8,6 +8,7 @@ import sys
 import os
 import json
 import tempfile
+import traceback
 
 # Ajouter le répertoire au path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -100,7 +101,9 @@ class MockTkinter:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+        if exc_type:
+            traceback.print_exc()
+        return False
 
 def run_basic_validation():
     """Lance une validation de base de l'application"""


### PR DESCRIPTION
## Summary
- add import logging/traceback to package init and log import errors
- log TclError in `set_tools_enabled` and print stack traces
- include traceback output for diagnostic subprocess failures
- show stack traces for destroyed widgets
- enhance check_coherence error logs
- print traceback in validation helper context manager

## Testing
- `python comparateur_jsonV9/validate_improvements.py`

------
https://chatgpt.com/codex/tasks/task_b_68407c32501c8331a267713f478648ea